### PR TITLE
Add ellipsoid class

### DIFF
--- a/ellipsoid/v1/CMakeLists.txt
+++ b/ellipsoid/v1/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(ellipsoid LANGUAGES CXX)
+
+# Import third-party dependencies.
+find_package(GTest REQUIRED CONFIG)
+
+# Enable some compiler warnings (supported by gcc & clang).
+set(warnings
+    -Wall
+    -Wconversion
+    -Werror
+    -Wextra
+    -Wformat=2
+    -Wold-style-cast
+    -Woverloaded-virtual
+    -Wshadow
+    -Wsign-conversion
+    -Wuninitialized
+    -Wunused
+    )
+string(REPLACE ";" " " warnings "${warnings}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${warnings}")
+
+add_library(ellipsoid SHARED)
+add_library(caesar::ellipsoid ALIAS ellipsoid)
+
+# Require C++17.
+target_compile_features(ellipsoid PUBLIC cxx_std_17)
+
+# Add sources.
+set(sources
+    caesar/spheroid.cpp
+    )
+target_sources(ellipsoid PRIVATE ${sources})
+
+# Add include dirs.
+target_include_directories(
+    ellipsoid
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+    )
+
+# Add test sources.
+set(tests
+    test/spheroid_test.cpp
+    )
+
+add_executable(ellipsoid-test ${tests})
+
+target_link_libraries(
+    ellipsoid-test
+    PRIVATE
+        caesar::ellipsoid
+        GTest::gtest_main
+    )
+
+# Register tests with CTest.
+enable_testing()
+include(GoogleTest)
+gtest_discover_tests(ellipsoid-test)

--- a/ellipsoid/v1/caesar/spheroid.cpp
+++ b/ellipsoid/v1/caesar/spheroid.cpp
@@ -1,0 +1,1 @@
+#include "spheroid.hpp"

--- a/ellipsoid/v1/caesar/spheroid.hpp
+++ b/ellipsoid/v1/caesar/spheroid.hpp
@@ -50,14 +50,14 @@ public:
      *
      * \see Spheroid::a
      */
-    constexpr double
+    [[nodiscard]] constexpr double
     semimajor_axis() const noexcept
     {
         return a();
     }
 
     /** Same as Spheroid::semimajor_axis() */
-    constexpr double
+    [[nodiscard]] constexpr double
     a() const noexcept
     {
         return a_;
@@ -70,14 +70,14 @@ public:
      *
      * \see Spheroid::b
      */
-    constexpr double
+    [[nodiscard]] constexpr double
     semiminor_axis() const noexcept
     {
         return b();
     }
 
     /** Same as Spheroid::semiminor_axis() */
-    constexpr double
+    [[nodiscard]] constexpr double
     b() const noexcept
     {
         return a() * (1. - f());
@@ -88,14 +88,14 @@ public:
      *
      * \see Spheroid::f
      */
-    constexpr double
+    [[nodiscard]] constexpr double
     flattening() const noexcept
     {
         return f();
     }
 
     /** Same as Spheroid::flattening() */
-    constexpr double
+    [[nodiscard]] constexpr double
     f() const noexcept
     {
         return f_;
@@ -106,7 +106,7 @@ public:
      *
      * \see Spheroid::flattening
      */
-    constexpr double
+    [[nodiscard]] constexpr double
     inverse_flattening() const
     {
         return 1. / f();
@@ -121,7 +121,7 @@ public:
      * n = \frac{a - b}{a + b}
      * \f]
      */
-    constexpr double
+    [[nodiscard]] constexpr double
     third_flattening() const noexcept
     {
         return f() / (2. - f());
@@ -136,7 +136,7 @@ public:
      * e = \sqrt{1 - \frac{b^2}{a^2}}
      * \f]
      */
-    double
+    [[nodiscard]] double
     eccentricity() const
     {
         return std::sqrt(squared_eccentricity());
@@ -147,21 +147,21 @@ public:
      *
      * \see Spheroid::eccentricity
      */
-    constexpr double
+    [[nodiscard]] constexpr double
     squared_eccentricity() const noexcept
     {
         return f() * (2. - f());
     }
 
     /** Compare two Spheroid objects. */
-    friend constexpr bool
+    [[nodiscard]] friend constexpr bool
     operator==(const Spheroid& lhs, const Spheroid& rhs) noexcept
     {
         return lhs.a() == rhs.a() and lhs.f() == rhs.f();
     }
 
     /** \copydoc operator==(const Spheroid&, const Spheroid&) */
-    friend constexpr bool
+    [[nodiscard]] friend constexpr bool
     operator!=(const Spheroid& lhs, const Spheroid& rhs) noexcept
     {
         return not(lhs == rhs);

--- a/ellipsoid/v1/caesar/spheroid.hpp
+++ b/ellipsoid/v1/caesar/spheroid.hpp
@@ -1,0 +1,178 @@
+#pragma once
+
+#include <cmath>
+
+namespace caesar {
+
+/**
+ * An ellipsoid with two axes of equal length
+ *
+ * A spheroid is parameterized by its semi-major and semi-minor axis lengths,
+ * \f$a\f$ and \f$b\f$ as
+ *
+ * \f[
+ * \frac{x^2 + y^2}{a^2} + \frac{z^2}{b^2} = 1
+ * \f]
+ *
+ * In geodesy, a spheroid is typically used as a geodetic reference ellipsoid
+ * that approximates the size and shape of the Earth. In such applications, the
+ * semi-major axis length describes the equatorial radius and the semi-minor
+ * axis length describes the polar radius.
+ *
+ * Reference ellipsoids are commonly specified by their semi-major axis and
+ * flattening constant, \f$f\f$, defined as
+ *
+ * \f[
+ * f = \frac{a - b}{a}
+ * \f]
+ *
+ * The flattening is a measure of the ellipticity of the spheroid. If the
+ * flattening is between 0 and 1, the spheroid is oblate (\f$a > b\f$). If it's
+ * equal to 0, the spheroid is a perfect sphere (\f$a == b\f$). If it's less
+ * than zero, the spheroid is prolate (\f$a < b\f$).
+ *
+ * \see wgs84_ellipsoid
+ */
+class Spheroid {
+public:
+    /**
+     * Construct a new Spheroid object.
+     *
+     * \param[in] a semi-major axis length
+     * \param[in] f flattening constant
+     */
+    constexpr Spheroid(double a, double f) noexcept : a_(a), f_(f) {}
+
+    /**
+     * Return the semi-major axis length.
+     *
+     * In geodetic applications, this is the equatorial radius.
+     *
+     * \see Spheroid::a
+     */
+    constexpr double
+    semimajor_axis() const noexcept
+    {
+        return a();
+    }
+
+    /** Same as Spheroid::semimajor_axis() */
+    constexpr double
+    a() const noexcept
+    {
+        return a_;
+    }
+
+    /**
+     * Return the semi-minor axis length.
+     *
+     * In geodetic applications, this is the polar radius.
+     *
+     * \see Spheroid::b
+     */
+    constexpr double
+    semiminor_axis() const noexcept
+    {
+        return b();
+    }
+
+    /** Same as Spheroid::semiminor_axis() */
+    constexpr double
+    b() const noexcept
+    {
+        return a() * (1. - f());
+    }
+
+    /**
+     * Return the (first) flattening.
+     *
+     * \see Spheroid::f
+     */
+    constexpr double
+    flattening() const noexcept
+    {
+        return f();
+    }
+
+    /** Same as Spheroid::flattening() */
+    constexpr double
+    f() const noexcept
+    {
+        return f_;
+    }
+
+    /**
+     * Return the inverse flattening constant, \f$\frac{1}{f}\f$.
+     *
+     * \see Spheroid::flattening
+     */
+    constexpr double
+    inverse_flattening() const
+    {
+        return 1. / f();
+    }
+
+    /**
+     * Return the third flattening.
+     *
+     * The third flattening, \f$n\f$, is defined as
+     *
+     * \f[
+     * n = \frac{a - b}{a + b}
+     * \f]
+     */
+    constexpr double
+    third_flattening() const noexcept
+    {
+        return f() / (2. - f());
+    }
+
+    /**
+     * Return the eccentricity of the spheroid.
+     *
+     * The eccentricity, ]f$e\f$, is defined as
+     *
+     * \f[
+     * e = \sqrt{1 - \frac{b^2}{a^2}}
+     * \f]
+     */
+    double
+    eccentricity() const
+    {
+        return std::sqrt(squared_eccentricity());
+    }
+
+    /**
+     * Return the squared eccentricity.
+     *
+     * \see Spheroid::eccentricity
+     */
+    constexpr double
+    squared_eccentricity() const noexcept
+    {
+        return f() * (2. - f());
+    }
+
+    /** Compare two Spheroid objects. */
+    friend constexpr bool
+    operator==(const Spheroid& lhs, const Spheroid& rhs) noexcept
+    {
+        return lhs.a() == rhs.a() and lhs.f() == rhs.f();
+    }
+
+    /** \copydoc operator==(const Spheroid&, const Spheroid&) */
+    friend constexpr bool
+    operator!=(const Spheroid& lhs, const Spheroid& rhs) noexcept
+    {
+        return not(lhs == rhs);
+    }
+
+private:
+    double a_;
+    double f_;
+};
+
+/** World Geodetic System 1984 (WGS 84) reference ellipsoid */
+inline constexpr Spheroid wgs84_ellipsoid(6378137.0, 1.0 / 298.257223563);
+
+} // namespace caesar

--- a/ellipsoid/v1/test/spheroid_test.cpp
+++ b/ellipsoid/v1/test/spheroid_test.cpp
@@ -1,0 +1,123 @@
+#include <caesar/spheroid.hpp>
+
+#include <cmath>
+#include <gtest/gtest.h>
+
+namespace cs = caesar;
+
+TEST(SpheroidTest, Construct)
+{
+    const double a = 2.0;
+    const double f = 0.5;
+    const auto spheroid = cs::Spheroid(a, f);
+
+    EXPECT_DOUBLE_EQ(spheroid.a(), a);
+    EXPECT_DOUBLE_EQ(spheroid.semimajor_axis(), a);
+    EXPECT_DOUBLE_EQ(spheroid.f(), f);
+    EXPECT_DOUBLE_EQ(spheroid.flattening(), f);
+}
+
+TEST(SpheroidTest, SemiminorAxis)
+{
+    const double a = 4.0;
+
+    // Oblate spheroid
+    {
+        const double f = 0.5;
+        const auto spheroid = cs::Spheroid(a, f);
+
+        EXPECT_DOUBLE_EQ(spheroid.b(), 2.0);
+        EXPECT_DOUBLE_EQ(spheroid.semiminor_axis(), 2.0);
+    }
+
+    // Prolate spheroid
+    {
+        const double f = -0.25;
+        const auto spheroid = cs::Spheroid(a, f);
+
+        EXPECT_DOUBLE_EQ(spheroid.b(), 5.0);
+        EXPECT_DOUBLE_EQ(spheroid.semiminor_axis(), 5.0);
+    }
+
+    // Sphere
+    {
+        const double f = 0.0;
+        const auto spheroid = cs::Spheroid(a, f);
+
+        EXPECT_DOUBLE_EQ(spheroid.b(), 4.0);
+        EXPECT_DOUBLE_EQ(spheroid.semiminor_axis(), 4.0);
+    }
+}
+
+TEST(SpheroidTest, InverseFlattening)
+{
+    const double a = 1.0;
+    const double f = 0.5;
+    const auto spheroid = cs::Spheroid(a, f);
+
+    EXPECT_DOUBLE_EQ(spheroid.inverse_flattening(), 2.0);
+}
+
+TEST(SpheroidTest, ThirdFlattening)
+{
+    const double a = 2.0;
+
+    {
+        const double f = 0.5;
+        const auto spheroid = cs::Spheroid(a, f);
+
+        EXPECT_DOUBLE_EQ(spheroid.third_flattening(), 1.0 / 3.0);
+    }
+
+    {
+        const double f = -0.5;
+        const auto spheroid = cs::Spheroid(a, f);
+
+        EXPECT_DOUBLE_EQ(spheroid.third_flattening(), -0.2);
+    }
+}
+
+TEST(SpheroidTest, Eccentricity)
+{
+    const double a = 2.0;
+
+    {
+        const double f = 0.0;
+        const auto spheroid = cs::Spheroid(a, f);
+
+        EXPECT_DOUBLE_EQ(spheroid.squared_eccentricity(), 0.0);
+        EXPECT_DOUBLE_EQ(spheroid.eccentricity(), 0.0);
+    }
+
+    {
+        const double f = 0.5;
+        const auto spheroid = cs::Spheroid(a, f);
+
+        EXPECT_DOUBLE_EQ(spheroid.squared_eccentricity(), 0.75);
+        EXPECT_DOUBLE_EQ(spheroid.eccentricity(), std::sqrt(0.75));
+    }
+
+    {
+        const double f = 1.0;
+        const auto spheroid = cs::Spheroid(a, f);
+
+        EXPECT_DOUBLE_EQ(spheroid.squared_eccentricity(), 1.0);
+        EXPECT_DOUBLE_EQ(spheroid.eccentricity(), 1.0);
+    }
+}
+
+TEST(SpheroidTest, Compare)
+{
+    const auto spheroid1 = cs::Spheroid(2., 0.5);
+    const auto spheroid2 = cs::Spheroid(2., 0.5);
+    const auto spheroid3 = cs::Spheroid(1., 1.0);
+
+    EXPECT_TRUE(spheroid1 == spheroid2);
+    EXPECT_TRUE(spheroid1 != spheroid3);
+}
+
+TEST(SpheroidTest, WGS84Ellipsoid)
+{
+    EXPECT_DOUBLE_EQ(cs::wgs84_ellipsoid.semimajor_axis(), 6378137.0);
+    EXPECT_DOUBLE_EQ(cs::wgs84_ellipsoid.inverse_flattening(), 298.257223563);
+}


### PR DESCRIPTION
This PR demos a class for representing geodetic reference ellipsoids. In isce3, this is the role of the [`Ellipsoid`](https://github.com/isce-framework/isce3/blob/0eb175f86f6c74d86c19ba9623f23054513fc657/cxx/isce3/core/Ellipsoid.h) class. The main differences between this implementation and the one in isce3 are:

- Renamed "Ellipsoid" -> "Spheroid"
   - The shape that we typically refer to as an "ellipsoid" is actually a particular type of ellipsoid called a ["spheroid"](https://en.wikipedia.org/wiki/Spheroid). While an ellipsoid has 3 axes of independent lengths, two of the axes of a spheroid are always of equal length.
- Changed constructor arguments
   - isce3's Ellipsoid is constructed by passing a semi-major axis length and eccentricity constant. My understanding is that it's more common in literature to describe geodetic reference ellipsoids by their semi-major axis length and *flattening* (or inverse flattening) coefficient, so I've changed the constructor to be consistent with that convention.
- Removed default constructor
   - In isce3, Ellipsoid can be default constructed to create a WGS 84 ellipsoid. This has been removed and replaced with a global constant called `wgs84_ellipsoid`.

Some of the higher-level, more complicated functionality of Ellipsoid has also been removed here to just focus on the basics. (Almost) all of the remaining interface is now `constexpr`.